### PR TITLE
jdk 8 and flink 1.14.0 in pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,11 +8,18 @@
     <artifactId>ASI_UDX</artifactId>
     <version>1.0-SNAPSHOT</version>
 
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <flink.version>1.14.0</flink.version>
+        <scala.version>2.11</scala.version>
+    </properties>
+             
     <dependencies>
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-table-common</artifactId>
-            <version>1.12.7</version>
+            <version>${flink.version}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
1. If client JDK is 11+, this pom will lead to a compile error, without <maven.compiler.source>8</maven.compiler.source> and <maven.compiler.target>8</maven.compiler.target> in <properties>.
2. make <flink.version> as a public variable, and modified version to flink v1.14.0